### PR TITLE
Use "/usr/bin/env node" to be system independent

### DIFF
--- a/docter.js
+++ b/docter.js
@@ -1,14 +1,14 @@
-#!/usr/local/bin/node
+#!/usr/bin/env node
 var exec = require('child_process').exec,
 	spawn = require('child_process').spawn,
 	// gfm = spawn('./bin/github-flavored-markdown.rb');
 	gfm = spawn('/usr/local/bin/gfm');
-	
+
 	gfm.stdout.on('data', function(data) {
 		process.stdout.write(data);
 	});
 	gfm.on('exit',function(ecode){
-		
+
 	})
 
 process.stderr.on('data',function(err) {


### PR DESCRIPTION
On Ubuntu 13.04 with recent nodejs old path doesn't exists
