### PR TITLE
Enable viewing in a narrower browser window

### DIFF
--- a/ghf_marked.css
+++ b/ghf_marked.css
@@ -13,7 +13,7 @@ body {
   padding: 20px;
 	text-align:left;
 	color: #333;
-	width:920px;
+	max-width:920px;
 }
 
 .md {


### PR DESCRIPTION
By specifying a maximum width rather than a fixed width. This is useful if you are
splitting the screen between your editor and browser.