### PR TITLE
Fixed TypeError with node(> v0.9)

### DIFF
--- a/docter.js
+++ b/docter.js
@@ -11,9 +11,9 @@ var exec = require('child_process').exec,
 
 	})
 
-process.stderr.on('data',function(err) {
+process.stderr.readable && (process.stderr.on('data',function(err) {
 	process.stdout.write('ERR: '+err);
-})
+}))
 
 process.stdin.resume();
 process.stdin.setEncoding('utf8');


### PR DESCRIPTION
In node v0.10.35, occurred below error.

_stream_readable.js:764
    while (!paused && (null !== (c = stream.read())))
                                            ^
TypeError: Property 'read' of object #<Socket> is not a function
    at Socket.<anonymous> (_stream_readable.js:764:45)
    at Socket.emit (events.js:92:17)
    at emitDataEvents (_stream_readable.js:790:10)
    at Socket.Readable.on (_stream_readable.js:711:5)
    at Object.<anonymous> (/usr/local/lib/node_modules/docter/docter.js:14:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Function.Module.runMain (module.js:497:10)